### PR TITLE
Add community directory page driven by JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # DFW Pogo
-Repository gor cudtim webapp for DFW Pokemon Go comms. 
+Repository for custom webapp for DFW Pokémon GO community.
+
+## Community Directory
+`communities.html` displays local groups using data from `communities.json`. Update the JSON file to change the listing.

--- a/communities.html
+++ b/communities.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="dfwstyle.css" />
+  <title>DFW Pokémon GO Communities</title>
+</head>
+<body>
+  <header>
+    <h1>DFW Pokémon GO Communities</h1>
+  </header>
+  <main>
+    <ul id="community-list"></ul>
+  </main>
+  <footer>
+    Created for DFW Trainers
+  </footer>
+  <script src="js/communities.js"></script>
+</body>
+</html>

--- a/communities.json
+++ b/communities.json
@@ -1,0 +1,87 @@
+[
+  {
+    "name": "DFW Area Pokémon Go",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPTJiMmJhNjhlLWEwM2EtNDgwNi05NTQ4LWI2ZTNmOTBkN2JhNSZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "Heights Park Raid Squad",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPTJiMWJiZTk5LTI3OTAtNGUyMC1hMDVhLTY1OTkxNGJjN2U5MCZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "Garland Go Group",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPTc0Y2QzNTVlLWM3ZGMtNDJhZC1hNGQ2LTBhYTViODNiZjM1ZiZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "Plano Raiders",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPTVhNDY5OTRlLWRiNzEtNDUzMS04MmQ0LTEyYTVmZWY3ZWZjYiZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "ACFB",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPWEwZmJhMjk2LTY5ZjEtNGZlNy1hZjNhLWY3ZTBkNjM5ZDM0NiZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "GPI Pokemon",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPWE1Y2Y1NjY1LTRmNjUtNDdmOS1iYzBhLTE2ZWU4NWE5Y2EwZCZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "Allen Pogo",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPTQ1MTZlMTIxLTA1MWYtNGM3Mi1iYWE1LWE5YzliMDgyMmU2OCZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "My Frisco Pokémon",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPTlhZjk5MjBhLTI3Y2UtNDUzZC05YzU4LWNjZTYyMzU5ZDU1MiZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "The Colony PokeBallers",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPWU5OTVmNTBmLTM0MDctNDgyZC1iZTJiLTg0NGI2NjMyZTFmZiZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "Crawford Raids",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPWE1YTI1ZDY4LTcxYTAtNGE4ZC1iYjdmLTg0MzUyYWY4N2RiZiZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "SeaGo Bruce Central Park",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPTliMmM5MzE5LWJhOTEtNDIzMi1hYzNiLWEwYjJhYWRlZTJjNSZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "POGO Mansfield",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPWUwMTEyY2ZkLWZjZDYtNGQ4MC04OTBiLTU0NGM1MGE0ZjA3NCZpPXRydWU=",
+    "hasAmbassador": false
+  },
+  {
+    "name": "DFW Traders",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPWM1ODY4Y2Y4LWIyMGQtNDg4Ny05NzRiLWJmMzg1MTJlYWRhMiZpPXRydWU=",
+    "hasAmbassador": false
+  },
+  {
+    "name": "Southlake Town Square Trainers",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPTg4NGQ4YzdmLTYyMjctNDdjOC04ODNiLWFiYjNhMzZjZGQ0MiZpPXRydWU=",
+    "hasAmbassador": false
+  },
+  {
+    "name": "Hurst, Euless, Bedford TX",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPTZjMThhNzc0LWQ5NWUtNDUxZC05NTExLTI4MzhmY2UwYTIwOCZpPXRydWU=",
+    "hasAmbassador": false
+  },
+  {
+    "name": "South Fort Worth",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPWQxZTk0YzM2LWZlOTEtNGM2OS04YjExLTIzOTc2ZWNmMGI5YyZpPXRydWU=",
+    "hasAmbassador": true
+  },
+  {
+    "name": "Coppell",
+    "url": "https://campfire.onelink.me/eBr8?af_dp=campfire://&af_force_deeplink=true&deep_link_sub1=cj1jbHVicyZjPWI1ODFjNWRjLTA0NjctNGFkMi04OTUwLTM0NDU3NDJlZmVhNSZpPXRydWU=",
+    "hasAmbassador": false
+  }
+]

--- a/dfwstyle.css
+++ b/dfwstyle.css
@@ -210,3 +210,12 @@ a:focus {
   color: #cc0000;
   text-decoration: underline;
 }
+
+/* Community list styles */
+#community-list li.ambassador {
+  color: green;
+}
+
+#community-list li.no-ambassador {
+  color: #666;
+}

--- a/js/communities.js
+++ b/js/communities.js
@@ -1,0 +1,26 @@
+fetch('communities.json')
+  .then(response => response.json())
+  .then(data => {
+    const list = document.getElementById('community-list');
+    data.forEach(group => {
+      const li = document.createElement('li');
+      li.className = group.hasAmbassador ? 'ambassador' : 'no-ambassador';
+
+      const link = document.createElement('a');
+      link.href = group.url;
+      link.textContent = group.name;
+      link.target = '_blank';
+
+      const status = document.createElement('span');
+      status.textContent = group.hasAmbassador
+        ? ' : Has a Niantic Community Ambassador'
+        : ' : Does Not Have a Community Ambassador';
+
+      li.appendChild(link);
+      li.appendChild(status);
+      list.appendChild(li);
+    });
+  })
+  .catch(err => {
+    console.error('Failed to load communities:', err);
+  });


### PR DESCRIPTION
## Summary
- list DFW Pokémon GO communities on a new `communities.html` page
- load groups dynamically from `communities.json`
- add simple styles and document how to update the directory

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d05a871948330b09057b7026b8257