### PR TITLE
Support markdown images and fix markdown section styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@ Repository for custom webapp for DFW Pokémon GO community.
 
 ## Community Directory
 `communities.html` displays local groups using data from `communities.json`. Update the JSON file to change the listing.
+
+## Markdown Content
+Event and update pages are built from Markdown files (for example, `weekdayevents.md`).
+You can embed images in these files using standard Markdown syntax:
+
+```
+![Alt text](img/example.png)
+```
+
+Images included this way will automatically scale to fit the layout.

--- a/dfwstyle.css
+++ b/dfwstyle.css
@@ -24,6 +24,15 @@
 .markdown-section tr:last-child td {
   border-bottom: none;
 }
+
+/* Ensure markdown images scale and align consistently */
+.markdown-intro img,
+.markdown-section img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0.5em 0;
+}
 body {
       font-family: 'Segoe UI', sans-serif;
       margin: 0;

--- a/index.html
+++ b/index.html
@@ -206,6 +206,7 @@
           details.appendChild(summary);
           if (sec.content) {
             const contentDiv = document.createElement('div');
+            contentDiv.className = 'markdown-section';
             contentDiv.innerHTML = marked.parse(sec.content);
             details.appendChild(contentDiv);
           }


### PR DESCRIPTION
## Summary
- Ensure markdown sections within collapsible details receive styling
- Add CSS rules so images embedded in markdown scale responsively
- Document how to include images in markdown content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689553faecf48330a5f4498895376965